### PR TITLE
Astro scale corrections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useState } from 'react';
 import { LayersControl, MapContainer, TileLayer, useMap, useMapEvents } from 'react-leaflet';
 import { latLng, LatLngBounds, latLngBounds } from 'leaflet';
 import { mapOptions, SERVICE_URL, DEFAULT_MIN_ZOOM } from './configs/mapSettings';
-import { BandWithLayerName, MapMetadataResponse, MapResponse } from './types/maps';
+import { BandWithLayerName, GraticuleDetails, MapMetadataResponse, MapResponse } from './types/maps';
 import { makeLayerName } from './utils/layerUtils';
 import { getControlPaneOffsets } from './utils/paneUtils';
 import { ColorMapControls } from './components/ColorMapControls';
 import { CoordinatesDisplay } from './components/CoordinatesDisplay';
-// import { AstroScale } from './components/AstroScale';
+import { AstroScale } from './components/AstroScale';
 import { AreaSelection } from './components/AreaSelection';
 import { GraticuleLayer } from './components/GraticuleLayer';
 
@@ -18,6 +18,7 @@ function App() {
   const [activeLayer, setActiveLayer] = useState<BandWithLayerName | undefined>(undefined);
   const [bands, setBands] = useState<BandWithLayerName[] | undefined>(undefined);
   const [selectionBounds, setSelectionBounds] = useState<LatLngBounds | undefined>(undefined);
+  const [graticuleDetails, setGraticuleDetails] = useState<undefined | GraticuleDetails>(undefined);
 
   useEffect(() => {
     async function getMapsAndMetadata() {
@@ -102,9 +103,9 @@ function App() {
               }
             )}
           </LayersControl>
-          <GraticuleLayer />
+          <GraticuleLayer setGraticuleDetails={setGraticuleDetails} />
           <CoordinatesDisplay />
-          {/* <AstroScale /> */}
+          {graticuleDetails && <AstroScale graticuleDetails={graticuleDetails} />}
           <AreaSelection handleSelectionBounds={setSelectionBounds} />
           <MapEvents onBaseLayerChange={onBaseLayerChange} selectionBounds={selectionBounds} />
         </MapContainer>

--- a/src/components/AstroScale.tsx
+++ b/src/components/AstroScale.tsx
@@ -13,25 +13,20 @@ interface AstroScaleOptions extends L.ControlOptions {
 const AstroControl = L.Control.Scale.extend({
     ...L.Control.Scale.prototype,
     _updateMetric: function() {
-	    // meters -> arcsec
         const degrees = (this.options as AstroScaleOptions).graticuleDetails.interval;
         const scaleWidth = (this.options as AstroScaleOptions).graticuleDetails.pixelWidth;
         let unitName = 'deg';
-	    // var maxArcsec = maxMeters / 30.87;
-	    // var maxUnit = maxArcsec;
-	    // var unitName = 'arcsec';
-	    // if (maxArcsec > 7200) {
-	    //     // degrees
-	    //     maxUnit /= 3600;
-	    //     unitName = 'deg';
-	    // } else if (maxArcsec >= 180) {
-	    //     // arcmin
-	    //     maxUnit /= 60;
-	    //     unitName = 'arcmin';
-	    // }
-	    // var unit = (this as any)._getRoundNum(maxUnit);
+        let value = degrees; 
+
+        if (degrees < 1/60) {
+            value = degrees * 60 * 60;
+            unitName = 'arcsec'
+        } else if (degrees < 1) {
+            value = degrees * 60;
+            unitName = 'arcmin'
+        }
 		(this as any)._mScale.style.width = scaleWidth + 'px';
-	    (this as any)._mScale.innerHTML = degrees + ' ' + unitName;
+	    (this as any)._mScale.innerHTML = value + ' ' + unitName;
     }
 })
 

--- a/src/components/AstroScale.tsx
+++ b/src/components/AstroScale.tsx
@@ -1,12 +1,10 @@
 import { createControlComponent } from "@react-leaflet/core";
 import L from "leaflet";
-import { MAX_SCALE_WIDTH } from "../configs/mapSettings";
 import { GraticuleDetails } from "../types/maps";
 
 interface AstroScaleOptions extends L.ControlOptions {
     position: L.ControlPosition;
     imperial: boolean;
-    maxWidth: number;
     graticuleDetails: GraticuleDetails;
   }
 
@@ -44,7 +42,6 @@ export function AstroScale({graticuleDetails}: Props) {
             key={graticuleDetails.pixelWidth + graticuleDetails.interval}
             position='bottomright'
             imperial={false}
-            maxWidth={MAX_SCALE_WIDTH}
             graticuleDetails={graticuleDetails}
         />
     )

--- a/src/components/AstroScale.tsx
+++ b/src/components/AstroScale.tsx
@@ -1,58 +1,56 @@
 import { createControlComponent } from "@react-leaflet/core";
-import { Control } from "leaflet";
+import L from "leaflet";
 import { MAX_SCALE_WIDTH } from "../configs/mapSettings";
+import { GraticuleDetails } from "../types/maps";
 
-/**
- * NOTE: I cast private vars and methods as "any" in order to remove some
- * annoying TS errors. We may want to figure out a more type-safe solution,
- * though Leaflet's source code confirms these vars and methods exist!
- * https://github.com/Leaflet/Leaflet/blob/main/src/control/Control.Scale.js
- */
+interface AstroScaleOptions extends L.ControlOptions {
+    position: L.ControlPosition;
+    imperial: boolean;
+    maxWidth: number;
+    graticuleDetails: GraticuleDetails;
+  }
 
-const AstroControl = Control.Scale.extend({
-    ...Control.Scale.prototype,
-    options: {
-        position: 'bottomright',
-	    imperial: false,
-	    maxWidth: MAX_SCALE_WIDTH,
-    },
-    _update() {
-        const map = (this as any)._map;
-        const center = map.getCenter();
-        const y = map.getSize().y / 2;
-        const maxMeters = map.distance(
-            map.containerPointToLatLng([0, y]),
-            map.containerPointToLatLng([this.options.maxWidth, y]),
-        );
-        // this calculation is based on info from https://www.opendem.info/arc2meters.html
-        const maxArcsec = Math.abs(maxMeters / (Math.cos(center.lat) * 1852 / 60));
-
-        (this as any)._updateScales(maxArcsec)
-    
-    },
-    _updateMetric: function(maxArcsec: number) {
-        // this method is adapted from the tilerfrontend prototype (see link)
-        // https://github.com/simonsobs/tilerfrontend/blob/65fb52ec9e70b061a47f4ec112552c4bf60e63e5/src/astroControl.ts#L13
-        // a notable difference is that I've passed in maxArcsec from the _update method in order to access the map's methods
-	    let maxUnit = maxArcsec;
-	    let unitName = 'arcsec';
-		
-	    if (maxArcsec > 7200) {
-	        // degrees
-	        maxUnit /= 3600;
-	        unitName = 'deg';
-	    } else if (maxArcsec >= 180) {
-	        // arcmin
-	        maxUnit /= 60;
-	        unitName = 'arcmin';
-	    }
-	    const unit = (this as any)._getRoundNum(maxUnit);
-        const ratio = unit/maxUnit;
-		(this as any)._mScale.style.width = Math.round(this.options.maxWidth * ratio) + 'px';
-	    (this as any)._mScale.innerHTML = unit + ' ' + unitName;
+const AstroControl = L.Control.Scale.extend({
+    ...L.Control.Scale.prototype,
+    _updateMetric: function() {
+	    // meters -> arcsec
+        const degrees = (this.options as AstroScaleOptions).graticuleDetails.interval;
+        const scaleWidth = (this.options as AstroScaleOptions).graticuleDetails.pixelWidth;
+        let unitName = 'deg';
+	    // var maxArcsec = maxMeters / 30.87;
+	    // var maxUnit = maxArcsec;
+	    // var unitName = 'arcsec';
+	    // if (maxArcsec > 7200) {
+	    //     // degrees
+	    //     maxUnit /= 3600;
+	    //     unitName = 'deg';
+	    // } else if (maxArcsec >= 180) {
+	    //     // arcmin
+	    //     maxUnit /= 60;
+	    //     unitName = 'arcmin';
+	    // }
+	    // var unit = (this as any)._getRoundNum(maxUnit);
+		(this as any)._mScale.style.width = scaleWidth + 'px';
+	    (this as any)._mScale.innerHTML = degrees + ' ' + unitName;
     }
 })
 
-export const AstroScale = createControlComponent(
-    (props) => new AstroControl(props),
+export const AstroScaleControl = createControlComponent(
+    (props: AstroScaleOptions) => new AstroControl(props),
 )
+
+type Props = {
+    graticuleDetails: {pixelWidth: number, interval: number};
+}
+
+export function AstroScale({graticuleDetails}: Props) {
+    return (
+        <AstroScaleControl
+            key={graticuleDetails.pixelWidth + graticuleDetails.interval}
+            position='bottomright'
+            imperial={false}
+            maxWidth={MAX_SCALE_WIDTH}
+            graticuleDetails={graticuleDetails}
+        />
+    )
+}

--- a/src/components/GraticuleLayer.tsx
+++ b/src/components/GraticuleLayer.tsx
@@ -2,8 +2,13 @@ import { useEffect } from "react";
 import { useMap } from "react-leaflet";
 import L from 'leaflet';
 import '../plugins/leaflet.latlng-graticule.js';
+import { GraticuleDetails } from "../types/maps.js";
 
-export function GraticuleLayer() {
+type Props = {
+    setGraticuleDetails: (details: GraticuleDetails) => void;
+}
+
+export function GraticuleLayer({setGraticuleDetails}: Props) {
     const map = useMap();
 
     useEffect(() => {
@@ -16,9 +21,16 @@ export function GraticuleLayer() {
                 {start: 2, end: 2, interval: 20},
                 {start: 3, end: 3, interval: 10},
                 {start: 4, end: 4, interval: 5},
-                {start: 5, end: 7, interval: 2},
-                {start: 8, end: 20, interval: 1}
-              ]
+                {start: 5, end: 5, interval: 2},
+                {start: 6, end: 6, interval: 1},
+                {start: 7, end: 7, interval: 0.5},
+                {start: 8, end: 8, interval: 0.2},
+                {start: 9, end: 20, interval: 0.1}
+              ],
+              fontColor: '#000',
+              lngFormatTickLabel: function(lng) { return Math.round(lng*1000)/1000; },
+              latFormatTickLabel: function(lat) { return Math.round(lat*1000)/1000; },
+              getCurrentGraticuleDetails: setGraticuleDetails,
         }).addTo(map);
 
         return () => {

--- a/src/configs/mapSettings.ts
+++ b/src/configs/mapSettings.ts
@@ -11,5 +11,4 @@ export const mapOptions: MapOptions = {
 export const DEFAULT_MIN_ZOOM = 0;
 
 // related to controls
-export const MAX_SCALE_WIDTH = 300;
 export const NUMBER_OF_FIXED_COORDINATE_DECIMALS = 5;

--- a/src/plugins/leaflet.latlng-graticule.js
+++ b/src/plugins/leaflet.latlng-graticule.js
@@ -332,6 +332,13 @@
                 _lon_r = parseInt(_lon_r + _point_per_lon, 10);
                 _lon_l = parseInt(_lon_l - _point_per_lon, 10);
 
+                if (this.options.getCurrentGraticuleDetails) {
+                    const p1 = self._latLngToCanvasPoint(L.latLng(_lat_b, lngInterval))
+                    const p2 = self._latLngToCanvasPoint(L.latLng(_lat_b, lngInterval * 2))
+                    const dX = Math.abs(p1.x - p2.x);
+                    this.options.getCurrentGraticuleDetails({pixelWidth: dX, interval: lngInterval});
+                }
+
                 var ll, latstr, lngstr, _lon_delta = 0.5;
                 function __draw_lat_line(self, lat_tick) {
                     ll = self._latLngToCanvasPoint(L.latLng(lat_tick, _lon_l));

--- a/src/types/leaflet-latlng-graticule.d.ts
+++ b/src/types/leaflet-latlng-graticule.d.ts
@@ -1,4 +1,5 @@
 import * as L from 'leaflet';
+import { GraticuleDetails } from './maps';
 
 /**  
  * Refer to leaflet.latlng-graticule's README for more details about the options
@@ -14,6 +15,9 @@ type GraticuleOptions = {
     dashArray?: number[];
     sides?: string[];
     zoomInterval?: {start: number, end: number, interval: number}[];
+    lngFormatTickLabel?: (lng: number) => number;
+    latFormatTickLabel?: (lat: number) => number;
+    getCurrentGraticuleDetails?: (details: GraticuleDetails) => void;
 }
 
 declare module 'leaflet' {

--- a/src/types/maps.ts
+++ b/src/types/maps.ts
@@ -40,3 +40,8 @@ export type HistogramResponse = {
     histogram: number[];
     band_id: number;
 }
+
+export type GraticuleDetails = {
+    pixelWidth: number,
+    interval: number,
+}


### PR DESCRIPTION
This PR aims to make an accurate scale based off of the graticule spacing. Leaflet's scale component does not appear accurate for non-mercator projections (see the [map.distance method](https://github.com/Leaflet/Leaflet/blob/142f94a9ba5757f7e7180ffa6cbed2b3a9bc73c9/src/geo/crs/CRS.Earth.js#L23) in the scale's update function).