### PR TITLE
Configure client to be bundled in tilemaker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@react-leaflet/core": "^2.1.0",
         "@svgdotjs/svg.js": "^3.2.4",
-        "dotenv": "^16.4.5",
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1864,18 +1863,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.23",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@react-leaflet/core": "^2.1.0",
     "@svgdotjs/svg.js": "^3.2.4",
-    "dotenv": "^16.4.5",
     "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/configs/mapSettings.ts
+++ b/src/configs/mapSettings.ts
@@ -1,6 +1,6 @@
 import { CRS, MapOptions } from "leaflet";
 
-export const SERVICE_URL: string = import.meta.env.VITE_SERVICE_URL || 'http://127.0.0.1:9191';
+export const SERVICE_URL: string = window.location.origin || 'http://127.0.0.1:9191';
 
 export const mapOptions: MapOptions = {
     center: [0.0, 0.0],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import dotenv from 'dotenv'
 
 // https://vitejs.dev/config/
 export default defineConfig(({mode}) => {
-  dotenv.config({path: mode === 'production' ? ['.env.production'] : ['env.development']})
   return {
       plugins: [react()],
       server: {
         host: true,
         port: 8080,
       },
-      base: process.env.VITE_BASE_PATH || ''
+      base: mode === 'production' ? '/static' : ''
     }
 })


### PR DESCRIPTION
These changes make it simpler and more flexible to bundle the client into [`tilemaker`](https://github.com/simonsobs/tilemaker) since it's now naive to its host origin.