### PR TITLE
Histogram bugs and improved documentation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,10 +53,24 @@ function App() {
     getMapsAndMetadata();
   }, [])
 
+  /** 
+   * Handler fires when user changes map layers. If the units of the new
+   * layer are the same as the active layer, then we just set a new active
+   * layer. If the units differ, we set new values for vmin, vmax, and cmap
+   * from the band's recommended values in order to prevent nonsensical
+   * TileLayer requests.
+   */
   const onBaseLayerChange = useCallback(
     (layer: L.TileLayer) => {
-      setActiveLayer(bands?.find(b => b.id === Number(layer.options.id)))
-    }, [bands, setActiveLayer]
+      const currentLayerUnits = activeLayer?.units
+      const newActiveLayer = bands?.find(b => b.id === Number(layer.options.id))
+      if (currentLayerUnits != newActiveLayer?.units) {
+        setVMin(newActiveLayer?.recommended_cmap_min)
+        setVMax(newActiveLayer?.recommended_cmap_max)
+        setCmap(newActiveLayer?.recommended_cmap)
+      }
+      setActiveLayer(newActiveLayer)
+    }, [bands, setActiveLayer, activeLayer, setVMin, setVMax, setCmap]
   )
 
   const onCmapValuesChange = useCallback(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,6 +116,7 @@ function App() {
             cmap={cmap}
             onCmapChange={onCmapChange}
             activeLayerId={activeLayer.id}
+            units={activeLayer.units}
           />
         )}
       </>

--- a/src/components/ColorMapControls.tsx
+++ b/src/components/ColorMapControls.tsx
@@ -140,7 +140,13 @@ export function ColorMapControls(props: ColorMapControlsProps) {
                                 </select>
                             </label>
                             {/* Button to "pop out" the CustomColorMapDialog component; button only displays when mouse enters the histogram */}
-                            <button onClick={() => setShowCustomDialog(true)} title="Customize parameters">&#x2197;</button>
+                            <button
+                                className="dialog-popout-btn"
+                                onClick={() => setShowCustomDialog(true)}
+                                title="Customize parameters"
+                            >
+                                &#x2197;
+                            </button>
                         </>
                     }
                 </div>

--- a/src/components/ColorMapControls.tsx
+++ b/src/components/ColorMapControls.tsx
@@ -1,4 +1,11 @@
-import { ChangeEventHandler, MouseEventHandler, useCallback, useEffect, useState } from "react";
+import { 
+    ChangeEventHandler, 
+    MouseEventHandler, 
+    useCallback, 
+    useEffect, 
+    useState, 
+    useMemo 
+} from "react";
 import { SERVICE_URL } from "../configs/mapSettings";
 import { CMAP_OPTIONS } from "../configs/cmapControlSettings";
 import { ColorMapSlider } from "./ColorMapSlider"
@@ -7,21 +14,43 @@ import { ColorMapHistogram } from "./ColorMapHistogram";
 import { CustomColorMapDialog } from "./CustomColorMapDialog";
 
 export type ColorMapControlsProps = {
+    /** the selected or default min and max values for the slider */
     values: number[]
+    /** handler to set new user-specified values for slider */
     onCmapValuesChange: (values: number[]) => void;
+    /** the color map selected in the cmap selector */
     cmap: string;
+    /** handler to set new color map */
     onCmapChange: (cmap: string) => void;
+    /** the id of the selected map layer */
     activeLayerId: number;
+    /** the units to display in the histogram range */
+    units: string;
 }
 
+/**
+ * A component that displays the ColorMapHistogram, along with components to control the histogram
+ * settings: a range slider for quick adjustments and a CustomColorMapDialog for more fine-tuned 
+ * adjusting.
+ * @param ColorMapControlsProps 
+ * @returns ColorMapControls
+ */
 export function ColorMapControls(props: ColorMapControlsProps) {
-    const {values, onCmapValuesChange, cmap, onCmapChange, activeLayerId} = props;
+    const {
+        values,
+        onCmapValuesChange,
+        cmap,
+        onCmapChange,
+        activeLayerId,
+        units,
+    } = props;
     const [cmapImage, setCmapImage] = useState<undefined | string>(undefined);
     const [histogramData, setHistogramData] = useState<HistogramResponse | undefined>(undefined);
     const [showCmapSelector, setShowCmapSelector] = useState(false);
     const [showCustomDialog, setShowCustomDialog] = useState(false);
     const [cmapOptions, setCmapOptions] = useState(CMAP_OPTIONS);
 
+    /** Fetch and set the URL to the color map image if/when cmap or its setter changes */
     useEffect(() => {
         async function getCmapImage() {
             const image = await fetch(`${SERVICE_URL}/histograms/${cmap}.png`)
@@ -30,15 +59,30 @@ export function ColorMapControls(props: ColorMapControlsProps) {
         getCmapImage();
     }, [cmap, setCmapImage])
 
+    /** Fetch and set the histogram data if/when the active layer and/or setHistogramData changes */
     useEffect(() => {
         async function getHistogramData() {
             const response = await fetch(`${SERVICE_URL}/histograms/data/${activeLayerId}`)
             const data: HistogramResponse = await response.json();
             setHistogramData(data);
         }
-        getHistogramData()
+        getHistogramData();
     }, [activeLayerId, setHistogramData])
 
+    /** Determines the min and max values for the range slider by comparing the
+        user-controlled (or default) 'values' to the histogram's 'edges'.
+        Allows for the range slider to resize itself according to min/max values
+        that may extend beyond the recommended cmap settings. */
+    const sliderMinAndMax = useMemo(
+        () => {
+            if (!histogramData) return
+            const min = Math.min(...histogramData.edges, values[0]);
+            const max = Math.max(...histogramData.edges, values[1]);
+            return {min, max}
+        }, [histogramData, values[0], values[1]]
+    )
+
+    /** Displays a <select> element for the color map when a user hovers over the histogram */
     const onMouseEnter: MouseEventHandler = useCallback(
         () => {
             if (!showCmapSelector) {
@@ -47,6 +91,7 @@ export function ColorMapControls(props: ColorMapControlsProps) {
         }, [showCmapSelector, setShowCmapSelector]
     )
 
+    /** Hides the <select> element for the color map when a user mouses away from the histogram */
     const onMouseLeave: MouseEventHandler = useCallback(
         (e) => {
             const el = e.target as HTMLElement
@@ -57,6 +102,7 @@ export function ColorMapControls(props: ColorMapControlsProps) {
         }, [showCmapSelector, setShowCmapSelector]
     )
 
+    /** Change handler for the color map <select> element */
     const handleCmapChange: ChangeEventHandler<HTMLSelectElement> = useCallback(
         (e) => {
             onCmapChange(e.target.value);
@@ -88,16 +134,26 @@ export function ColorMapControls(props: ColorMapControlsProps) {
                                     ))}
                                 </select>
                             </label>
+                            {/* Button to "pop out" the CustomColorMapDialog component; button only displays when mouse enters the histogram */}
                             <button onClick={() => setShowCustomDialog(true)} title="Customize parameters">&#x2197;</button>
                         </>
                     }
                 </div>
-                {histogramData && <ColorMapHistogram data={histogramData} />}
-                <ColorMapSlider
-                    cmapImage={cmapImage}
-                    values={values}
-                    onCmapValuesChange={onCmapValuesChange}
-                />
+                {histogramData && (
+                    <ColorMapHistogram
+                        data={histogramData}
+                        userMinAndMaxValues={{min: values[0], max: values[1]}}
+                    />
+                )}
+                {sliderMinAndMax && (
+                    <ColorMapSlider
+                        cmapImage={cmapImage}
+                        values={values}
+                        onCmapValuesChange={onCmapValuesChange}
+                        units={units}
+                        sliderMinAndMax={sliderMinAndMax}
+                    />
+                )}
             </div>
         
         </>

--- a/src/components/ColorMapHistogram.tsx
+++ b/src/components/ColorMapHistogram.tsx
@@ -5,14 +5,20 @@ import { HistogramResponse } from "../types/maps";
 import { HISTOGRAM_SIZE_X, HISTOGRAM_SIZE_Y } from "../configs/cmapControlSettings";
 
 type Props = {
+    /** The data from the histogram response */
     data: HistogramResponse,
+    /** The user's min and max values for the range slider to use as edgeStart or edgeEnd
+      in the event the user sets these beyond the histogram's min or max edges */
+    userMinAndMaxValues: {min: number, max: number}
 }
 
-export function ColorMapHistogram({data}: Props) {
+export function ColorMapHistogram({data, userMinAndMaxValues}: Props) {
     const { edges, histogram } = data;
     const logarithmicHistogram = histogram.map(Math.log10)
-    const edgeStart = Math.min(...edges);
-    const edgeEnd = Math.max(...edges);
+    /** Include user's min value in case we need to rescale the histogram accordingly */
+    const edgeStart = Math.min(...edges, userMinAndMaxValues.min);
+    /** Include user's max value in case we need to rescale the histogram accordingly */
+    const edgeEnd = Math.max(...edges, userMinAndMaxValues.max);
     
     const histogramStart = Math.min(...logarithmicHistogram);
     // Add a little buffer; we don't want the histogram to touch the top of the image

--- a/src/components/ColorMapHistogram.tsx
+++ b/src/components/ColorMapHistogram.tsx
@@ -3,6 +3,7 @@ import {
   } from "@svgdotjs/svg.js";
 import { HistogramResponse } from "../types/maps";
 import { HISTOGRAM_SIZE_X, HISTOGRAM_SIZE_Y } from "../configs/cmapControlSettings";
+import { safeLog } from "../utils/numberUtils";
 
 type Props = {
     /** The data from the histogram response */
@@ -14,7 +15,8 @@ type Props = {
 
 export function ColorMapHistogram({data, userMinAndMaxValues}: Props) {
     const { edges, histogram } = data;
-    const logarithmicHistogram = histogram.map(Math.log10)
+    /** Convert the histogram into log values using the safeLog utility function */
+    const logarithmicHistogram = histogram.map(safeLog)
     /** Include user's min value in case we need to rescale the histogram accordingly */
     const edgeStart = Math.min(...edges, userMinAndMaxValues.min);
     /** Include user's max value in case we need to rescale the histogram accordingly */

--- a/src/components/ColorMapSlider.tsx
+++ b/src/components/ColorMapSlider.tsx
@@ -8,9 +8,9 @@ interface ColorMapSlideProps extends
   Omit<ColorMapControlsProps, 'activeLayerId' | 'cmap' | 'onCmapChange'> {
     /** The URL to the color map image */
     cmapImage?: string;
-    /** The min and max values for the range slider, determined by histogram's min and max edge 
-      or the user's min and max setting */
-    sliderMinAndMax: {min: number, max: number};
+    /** The min, max, and step values for the range slider, determined by histogram's edges and
+      the user's min and max setting */
+    sliderAttributes: {min: number, max: number, step: number};
 }
 
 const regexToFindPercents = /\b\d+(\.\d+)?%/g;
@@ -21,7 +21,7 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
      * the RangeSlider has an onFinalChange handler that will set the global state once a user releases the slider handle
      */
     const [tempValues, setTempValues] = useState([props.values[0], props.values[1]])
-    const { cmapImage, onCmapValuesChange, units, sliderMinAndMax } = props;
+    const { cmapImage, onCmapValuesChange, units, sliderAttributes } = props;
 
     /** Sync the temp values  */
     useEffect(() => {
@@ -43,8 +43,8 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
     const trackBackground = getTrackBackground({
             values: tempValues,
             colors: ["#ccc", "#548BF4", "#ccc"],
-            min: sliderMinAndMax.min,
-            max: sliderMinAndMax.max,
+            min: sliderAttributes.min,
+            max: sliderAttributes.max,
         })
     const [ leftThumbPosition, rightThumbPosition ] = trackBackground
         .match(regexToFindPercents)?.map(p => p.replace('%', ''))
@@ -63,8 +63,9 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
               />
             )}
             <RangeSlider
-                min={sliderMinAndMax.min}
-                max={sliderMinAndMax.max}
+                min={sliderAttributes.min}
+                max={sliderAttributes.max}
+                step={sliderAttributes.step}
                 values={tempValues}
                 // Used to set component state while user is actively moving a slider "thumb"
                 onChange={(values) => setTempValues(values)}

--- a/src/components/ColorMapSlider.tsx
+++ b/src/components/ColorMapSlider.tsx
@@ -1,19 +1,32 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Range as RangeSlider, getTrackBackground } from 'react-range';
-import { MAX_TEMP, MIN_TEMP } from '../configs/cmapControlSettings';
+import { formatNumberForDisplay } from '../utils/numberUtils';
+import { ColorMapControlsProps } from './ColorMapControls';
 import './styles/color-map-controls.css';
 
-type ColorMapSlideProps = {
-    values: number[];
-    onCmapValuesChange: (values: number[]) => void;
+interface ColorMapSlideProps extends 
+  Omit<ColorMapControlsProps, 'activeLayerId' | 'cmap' | 'onCmapChange'> {
+    /** The URL to the color map image */
     cmapImage?: string;
+    /** The min and max values for the range slider, determined by histogram's min and max edge 
+      or the user's min and max setting */
+    sliderMinAndMax: {min: number, max: number};
 }
 
 const regexToFindPercents = /\b\d+(\.\d+)?%/g;
 
 export function ColorMapSlider(props: ColorMapSlideProps) {
-    const [values, setValues] = useState([props.values[0], props.values[1]])
-    const { cmapImage, onCmapValuesChange } = props;
+    /** 
+     * Create temporary values for range slider min/max to maintain component state without setting the global state;
+     * the RangeSlider has an onFinalChange handler that will set the global state once a user releases the slider handle
+     */
+    const [tempValues, setTempValues] = useState([props.values[0], props.values[1]])
+    const { cmapImage, onCmapValuesChange, units, sliderMinAndMax } = props;
+
+    /** Sync the temp values  */
+    useEffect(() => {
+      setTempValues([props.values[0], props.values[1]])
+    }, [props.values[0], props.values[1]])
 
     /** 
      * The getTrackBackground react-range function returns a string with a CSS gradient that
@@ -28,10 +41,10 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
      * which would result in the cmap image spanning the full length of the range slider.
     */
     const trackBackground = getTrackBackground({
-            values,
+            values: tempValues,
             colors: ["#ccc", "#548BF4", "#ccc"],
-            min: MIN_TEMP,
-            max: MAX_TEMP,
+            min: sliderMinAndMax.min,
+            max: sliderMinAndMax.max,
         })
     const [ leftThumbPosition, rightThumbPosition ] = trackBackground
         .match(regexToFindPercents)?.map(p => p.replace('%', ''))
@@ -50,13 +63,15 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
               />
             )}
             <RangeSlider
-                min={MIN_TEMP}
-                max={MAX_TEMP}
-                values={values}
-                onChange={(values) => setValues(values)}
+                min={sliderMinAndMax.min}
+                max={sliderMinAndMax.max}
+                values={tempValues}
+                // Used to set component state while user is actively moving a slider "thumb"
+                onChange={(values) => setTempValues(values)}
+                // Used to set higher-level state once user releases the slider "thumb"
                 onFinalChange={onCmapValuesChange}
                 renderThumb={({ props, isDragged }) => (
-                    <div
+                  <div
                     {...props}
                     key={props.key}
                     style={{
@@ -81,7 +96,7 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
                   </div>
                 )}
                 renderTrack={({ props, children }) => (
-                    <div
+                  <div
                     onMouseDown={props.onMouseDown}
                     onTouchStart={props.onTouchStart}
                     style={{
@@ -107,9 +122,13 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
                 )}
             />
             <div className="cmap-values-container">
-                <span className="cmap-value vmin">{values[0]}</span>
-                <span className="cmap-label"> &lt; T [&mu;K] &lt; </span>
-                <span className="cmap-value">{values[1]}</span>
+                <span className="cmap-value vmin">
+                  {formatNumberForDisplay(tempValues[0], 7)}
+                </span>
+                <span className="cmap-label"> &lt; {units} &lt; </span>
+                <span className="cmap-value">
+                  {formatNumberForDisplay(tempValues[1], 7)}
+                </span>
             </div>
         </>
     )

--- a/src/components/ColorMapSlider.tsx
+++ b/src/components/ColorMapSlider.tsx
@@ -102,7 +102,7 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
                     onTouchStart={props.onTouchStart}
                     style={{
                       ...props.style,
-                      height: "25px",
+                      height: "12px",
                       display: "flex",
                       zIndex: 2,
                     }}

--- a/src/components/CustomColorMapDialog.tsx
+++ b/src/components/CustomColorMapDialog.tsx
@@ -9,29 +9,47 @@ import './styles/color-map-dialog.css';
  */
 
 interface Props extends Omit<ColorMapControlsProps, 'activeLayerId'> {
+    /** Boolean to control dialog display/hide status */
     isOpen: boolean;
+    /** Handler to set modal to be closed */
     closeModal: () => void;
+    /** Handler that allows us to add new user-specified color maps to the histogram's <select> menu */
     setCmapOptions: (options: string[]) => void;
+    /** The list of color map options used to determine whether or not to append a new color map option */
     cmapOptions: string[];
 }
 
-export function CustomColorMapDialog({isOpen, closeModal, values, cmap, onCmapChange, onCmapValuesChange, cmapOptions, setCmapOptions}: Props) {
+export function CustomColorMapDialog({
+    isOpen,
+    closeModal,
+    values,
+    cmap,
+    onCmapChange,
+    onCmapValuesChange,
+    cmapOptions,
+    setCmapOptions,
+    units,
+}: Props) {
     const ref = useRef<HTMLDialogElement | null>(null);
+    // Create temporary values to maintain component state without setting the global state, which is only done during "Update Map" 
     const [tempCmap, setTempCmap] = useState(cmap);
     const [tempValues, setTempValues] = useState<Array<string | undefined>>(values.map(v => String(v)));
 
+    /** Sync the tempCmap with higher-level cmap state changes */
     useEffect(
         () => {
             setTempCmap(cmap)
         }, [cmap]
     )
 
+    /** Sync the tempValues with higher-level values state changes */
     useEffect(
         () => {
             setTempValues(values.map(v => String(v)))
         }, [values]
     )
 
+    /** Uses ref to HTMLDialogElement to control opening or closing the modal */
     useEffect(
         () => {
             if (isOpen) {
@@ -39,15 +57,18 @@ export function CustomColorMapDialog({isOpen, closeModal, values, cmap, onCmapCh
              } else {
                 ref.current?.close();
              }
-
+            
+            // Clean up function closes the modal when the component unmounts
             () => ref.current?.close();
         }, [isOpen]
     )
 
+    /** Handles "submitting" the temp values set in the dialog and closes the modal */
     const handleUpdate = useCallback(
         () => {
             onCmapChange(tempCmap);
             onCmapValuesChange(tempValues.map(v => v ? Number(v) : 0));
+            // Check if tempCmap exists in cmapOptions and concat as a new option if not
             if (!cmapOptions.includes(tempCmap)) {
                 setCmapOptions(cmapOptions.concat(tempCmap))
             }
@@ -77,11 +98,11 @@ export function CustomColorMapDialog({isOpen, closeModal, values, cmap, onCmapCh
                     <input type="text" value={tempCmap} onChange={(e) => setTempCmap(e.target.value)} />
                 </label>
                 <label>
-                    Minimum of T[&mu;K]
+                    Minimum of {units}
                     <input type="number" value={tempValues[0]} onChange={(e) => setTempValues(values => [e.target.value, values[1]])} />
                 </label>
                 <label>
-                    Maximum of T[&mu;K]
+                    Maximum of {units}
                     <input type="number" value={tempValues[1]} onChange={(e) => setTempValues(values => [values[0], e.target.value])} />
                 </label>
                 <input type="submit" value="Update Map" />

--- a/src/components/CustomColorMapDialog.tsx
+++ b/src/components/CustomColorMapDialog.tsx
@@ -93,17 +93,37 @@ export function CustomColorMapDialog({
             >
                 <label>
                     <span>
-                        Specify a <a target="_blank" href="https://matplotlib.org/stable/gallery/color/colormap_reference.html#colormap-reference">matplotlib colormap option</a>
+                        Specify a {' '}
+                        <a
+                            target="_blank"
+                            href="https://matplotlib.org/stable/gallery/color/colormap_reference.html#colormap-reference"
+                        >
+                            matplotlib colormap option
+                        </a>
                     </span>
                     <input type="text" value={tempCmap} onChange={(e) => setTempCmap(e.target.value)} />
                 </label>
                 <label>
                     Minimum of {units}
-                    <input type="number" value={tempValues[0]} onChange={(e) => setTempValues(values => [e.target.value, values[1]])} />
+                    <input
+                        type="number"
+                        step="any"
+                        // Prevent user from setting the min to be more than the max
+                        max={tempValues[1]}
+                        value={tempValues[0]}
+                        onChange={(e) => setTempValues(values => [e.target.value, values[1]])}
+                    />
                 </label>
                 <label>
                     Maximum of {units}
-                    <input type="number" value={tempValues[1]} onChange={(e) => setTempValues(values => [values[0], e.target.value])} />
+                    <input
+                        type="number"
+                        step="any"
+                        // Prevent user from setting the max to be less than the min
+                        min={tempValues[0]}
+                        value={tempValues[1]}
+                        onChange={(e) => setTempValues(values => [values[0], e.target.value])}
+                    />
                 </label>
                 <input type="submit" value="Update Map" />
             </form>

--- a/src/components/styles/color-map-controls.css
+++ b/src/components/styles/color-map-controls.css
@@ -13,10 +13,10 @@
   display: flex;
   justify-content: center;
   background-color: white;
-  font-size: 1.2em;
   box-shadow: 0px 2px 6px #AAA;
   border: 2px solid rgba(0,0,0,0.2);
   border-radius: 4px;
+  padding: 2px 0;
 }
 
 .cmap-label {
@@ -24,7 +24,7 @@
 }
 
 .cmap-value {
-  width: 50px;
+  width: 65px;
 }
 
 .cmap-value.vmin {

--- a/src/components/styles/color-map-controls.css
+++ b/src/components/styles/color-map-controls.css
@@ -2,11 +2,11 @@
     position: absolute;
     display: flex;
     flex-direction: column;
-    bottom: 10px;
+    bottom: 15px;
     left: 10px;
     z-index: 400;
     width: 200px;
-    height: 100px;
+    height: 90px;
   }
 
 .cmap-values-container {
@@ -50,14 +50,22 @@ select {
 img {
   position: absolute;
   height: 60px;
-  bottom: 40px;
+  bottom: 30px;
   opacity: 0.9;
   pointer-events: none;
 }
 
 .cmap-histogram {
   position: absolute;
-  bottom: 35px;
+  bottom: 30px;
   z-index: 1;
 }
 
+.dialog-popout-btn {
+  background-color: #2b2b2b;
+  border: 1px solid #616161;
+}
+
+.dialog-popout-btn:hover {
+  background-color: #565656;
+}

--- a/src/configs/cmapControlSettings.ts
+++ b/src/configs/cmapControlSettings.ts
@@ -1,4 +1,11 @@
+/** List of default color map options */
 export const CMAP_OPTIONS = ['RdBu_r', 'viridis', 'inferno'];
 
+/** The fixed width of the histogram */
 export const HISTOGRAM_SIZE_X = 200;
+
+/** The fixed height of the histogram */
 export const HISTOGRAM_SIZE_Y = 60;
+
+/** The number used to divide the range of the histogram edges */
+export const STEPS_DIVISOR = 500;

--- a/src/configs/cmapControlSettings.ts
+++ b/src/configs/cmapControlSettings.ts
@@ -1,6 +1,3 @@
-export const MIN_TEMP = -2000;
-export const MAX_TEMP = 2000;
-
 export const CMAP_OPTIONS = ['RdBu_r', 'viridis', 'inferno'];
 
 export const HISTOGRAM_SIZE_X = 200;

--- a/src/utils/layerUtils.ts
+++ b/src/utils/layerUtils.ts
@@ -3,9 +3,11 @@ import { Band } from "../types/maps";
 /**
  * A utility function to format a layer's name.
  * @param band The band object
- * @returns A string of map_name + quantity, where quantity is conditionally
- *          rendered based on its truthiness
+ * @returns A string of map_name + stokes_parameter + quantity, where quantity 
+ *  and stokes_parameter are conditionally rendered based on their truthiness
  */
 export function makeLayerName(band: Band) {
-    return band.map_name + (band.quantity ? ` ${band.quantity}` : '')
+    return band.map_name + 
+        (band.stokes_parameter ? ` ${band.stokes_parameter}` : '') + 
+        (band.quantity ? ` ${band.quantity}` : '')
 }

--- a/src/utils/numberUtils.ts
+++ b/src/utils/numberUtils.ts
@@ -60,3 +60,16 @@ function getExponentCharLength(expNumberString: string) {
     // the + or - rendered in the string
     return exponentStringLength - (exponent < 0 ? 1 : 0)
 }
+
+/**
+ * A utility that safely applies Math.log to numerical values
+ * @param x A number to process
+ * @returns 0 if x is 0 or less; otherwise its logarithmic value
+ */
+export function safeLog(x: number) {
+    if (x <= 0) {
+        return 0
+    } else {
+        return Math.log(x)
+    }
+}

--- a/src/utils/numberUtils.ts
+++ b/src/utils/numberUtils.ts
@@ -1,0 +1,62 @@
+/**
+ * Represents the base number of characters the exponential formatting consumes, excluding the actual
+ * exponent value.
+ * For example, 1234 -> 1.234e+3 and thus the 3 base characters are:
+ *  1. the decimal
+ *  2. the "e"
+ *  3. the "+" (or "-")
+ */
+const BASE_NUM_OF_CHARS_FOR_EXPONENTIAL_FORMATTING = 3;
+
+/**
+ * Used to restrict the length of numbers displayed in the UI so as to avoid
+ * any overflow issues. If the number's string length is less than maxChars,
+ * no formatting is applied. Otherwise, we return a string in exponential form
+ * with a number of decimal points determined by maxChars.
+ * @param number The number to be reformatted for display purposes
+ * @param maxChars The maximum number of characters in the string, defaults to 7
+ * @returns A string of the number either as-is or in exponential form
+ */
+export function formatNumberForDisplay(
+    number: number,
+    maxChars: number = 7,
+) {
+    const numString = String(number)
+    const numStringLength = numString.length;
+    if (numStringLength > maxChars) {
+        // At this point we need to determine how many exponents there are for the calculation
+        // of fractionDigits
+        const exponentCharLength = getExponentCharLength(number.toExponential())
+        // Check if exponentCharLength + BASE_NUM_OF_CHARS_FOR_EXPONENTIAL_FORMATTING exceeds maxChars
+        //  Y: set fractionDigits to 0
+        //  N: fractionDigits will be determined based on the two exponent char lengths
+        const fractionDigits = 
+            maxChars > (BASE_NUM_OF_CHARS_FOR_EXPONENTIAL_FORMATTING + exponentCharLength) ? 
+                maxChars - BASE_NUM_OF_CHARS_FOR_EXPONENTIAL_FORMATTING - exponentCharLength : 
+                0;
+        // Return the original number as a string in exponential form with the number of chars
+        // past the decimal as determined by fractionDigits
+        return number.toExponential(fractionDigits);
+    } else {
+        return numString;
+    }
+}
+
+/**
+ * A utility function that determines how many digits are in the exponent
+ * of a string returned by .toExponential()
+ * @param expNumberString The string value returned by .toExponential()
+ * @returns The number of exponent characters in the .toExponential() string format
+ */
+function getExponentCharLength(expNumberString: string) {
+    // Split the string at the "e"
+    const splitString = expNumberString.split("e");
+    // Cast the value of the exponent portion to a number
+    const exponent = Number(splitString[1]);
+    // Convert the exponent back to a string and grab its length
+    const exponentStringLength = String(exponent).length
+    // If the exponent is less than 0, subtract 1 from the length returned
+    // because the BASE_NUM_OF_CHARS_FOR_EXPONENTIAL_FORMATTING accounts for 
+    // the + or - rendered in the string
+    return exponentStringLength - (exponent < 0 ? 1 : 0)
+}


### PR DESCRIPTION
The changes to the histogram components in this branch include:
1. Syncing up the range slider's values with changes made using the dialog
2. Rendering the appropriate units in the dialog and the range slider
3. Using the `recommended_cmap_min` and `recommended_cmap_max` as the default values for the range slider
4. Using the histogram's edges as the default min and max for the histogram and range slider.
5. Re-scaling the color map and the histogram in the event a user sets a min and/or max value beyond the defaults (which a user can accomplish by setting those values in the unconstrained dialog inputs)
6. Formatting the displayed range values to prevent overflows
7. Adding documentation for future me (and others)