### PR TITLE
Minor map improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,9 @@ function App() {
   const [cmap, setCmap] = useState<string | undefined>(undefined);
 
   /** the active baselayer selected in the map's legend */
-  const [activeLayer, setActiveLayer] = useState<Band | undefined>(undefined);
+  const [activeBaselayer, setActiveBaselayer] = useState<Band | undefined>(
+    undefined
+  );
   /** bands are used as the baselayers of the map */
   const [bands, setBands] = useState<Band[] | undefined>(undefined);
   /** sourceLists are used as FeatureGroups in the map, which can be toggled on/off in the map legend */
@@ -105,7 +107,7 @@ function App() {
 
       // Default the active layer to be the first band of finalBands and set
       // the color map properties to its recommended values
-      setActiveLayer(finalBands[0]);
+      setActiveBaselayer(finalBands[0]);
       setVMin(finalBands[0].recommended_cmap_min);
       setVMax(finalBands[0].recommended_cmap_max);
       setCmap(finalBands[0].recommended_cmap);
@@ -150,7 +152,7 @@ function App() {
    */
   const onBaseLayerChange = useCallback(
     (layer: L.TileLayer) => {
-      const currentLayerUnits = activeLayer?.units;
+      const currentLayerUnits = activeBaselayer?.units;
       const newActiveLayer = bands?.find(
         (b) => b.id === Number(layer.options.id)
       );
@@ -159,9 +161,9 @@ function App() {
         setVMax(newActiveLayer?.recommended_cmap_max);
         setCmap(newActiveLayer?.recommended_cmap);
       }
-      setActiveLayer(newActiveLayer);
+      setActiveBaselayer(newActiveLayer);
     },
-    [bands, setActiveLayer, activeLayer, setVMin, setVMax, setCmap]
+    [bands, setActiveBaselayer, activeBaselayer, setVMin, setVMax, setCmap]
   );
 
   const onCmapValuesChange = useCallback(
@@ -183,8 +185,8 @@ function App() {
     composed from state at this level, we must construct it here and pass it down to the AreaSelection and
     HighlightBoxLayer components. */
   const submapData = useMemo(() => {
-    if (activeLayer) {
-      const { map_id: mapId, id: bandId } = activeLayer;
+    if (activeBaselayer) {
+      const { map_id: mapId, id: bandId } = activeBaselayer;
       return {
         mapId,
         bandId,
@@ -193,7 +195,7 @@ function App() {
         cmap,
       };
     }
-  }, [activeLayer, vmin, vmax, cmap]);
+  }, [activeBaselayer, vmin, vmax, cmap]);
 
   return (
     <>
@@ -204,7 +206,7 @@ function App() {
             return (
               <LayersControl.BaseLayer
                 key={`${band.map_name}-${band.id}`}
-                checked={band.id === activeLayer?.id}
+                checked={band.id === activeBaselayer?.id}
                 name={makeLayerName(band)}
               >
                 <TileLayer
@@ -289,15 +291,15 @@ function App() {
           setActiveBoxIds={setActiveBoxIds}
         />
       </MapContainer>
-      {vmin !== undefined && vmax !== undefined && cmap && activeLayer && (
+      {vmin !== undefined && vmax !== undefined && cmap && activeBaselayer && (
         <ColorMapControls
           values={[vmin, vmax]}
           onCmapValuesChange={onCmapValuesChange}
           cmap={cmap}
           onCmapChange={onCmapChange}
-          activeLayerId={activeLayer.id}
-          units={activeLayer.units}
-          quantity={activeLayer.quantity}
+          activeBaselayerId={activeBaselayer.id}
+          units={activeBaselayer.units}
+          quantity={activeBaselayer.quantity}
         />
       )}
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { AreaSelection } from './components/AreaSelection';
 import { GraticuleLayer } from './components/GraticuleLayer';
 import { fetchBoxes, fetchProducts } from './utils/fetchUtils';
 import { HighlightBoxLayer } from './components/HighlightBoxLayer';
+import './components/styles/map-baselayers.css';
 
 function App() {
   /** vmin, vmax, and cmap are matplotlib parameters used in the histogram components
@@ -207,6 +208,7 @@ function App() {
               >
                 <TileLayer
                   id={String(band.id)}
+                  className="tile-baselayer"
                   url={`${SERVICE_URL}/maps/${band.map_id}/${band.id}/{z}/{y}/{x}/tile.png?cmap=${cmap}&vmin=${vmin}&vmax=${vmax}`}
                   tms
                   noWrap

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,7 @@ import {
   FeatureGroup,
 } from 'react-leaflet';
 import { latLng, LatLngBounds, latLngBounds } from 'leaflet';
-import {
-  mapOptions,
-  SERVICE_URL,
-  DEFAULT_MIN_ZOOM,
-} from './configs/mapSettings';
+import { mapOptions, SERVICE_URL } from './configs/mapSettings';
 import {
   GraticuleDetails,
   MapMetadataResponse,
@@ -218,9 +214,7 @@ function App() {
                     latLng(band.bounding_top, band.bounding_left),
                     latLng(band.bounding_bottom, band.bounding_right)
                   )}
-                  minZoom={DEFAULT_MIN_ZOOM}
-                  maxZoom={band.levels + 3}
-                  minNativeZoom={band.levels - 4}
+                  maxZoom={Math.max(...bands.map((b) => b.levels)) + 3}
                   maxNativeZoom={band.levels - 1}
                 />
               </LayersControl.BaseLayer>

--- a/src/components/ColorMapControls.tsx
+++ b/src/components/ColorMapControls.tsx
@@ -26,8 +26,8 @@ export type ColorMapControlsProps = {
   cmap: string;
   /** handler to set new color map */
   onCmapChange: (cmap: string) => void;
-  /** the id of the selected map layer */
-  activeLayerId: number;
+  /** the id of the selected map baselayer */
+  activeBaselayerId: number;
   /** the units to display in the histogram range */
   units?: string;
   /** the quantity to display in the histogram range */
@@ -47,7 +47,7 @@ export function ColorMapControls(props: ColorMapControlsProps) {
     onCmapValuesChange,
     cmap,
     onCmapChange,
-    activeLayerId,
+    activeBaselayerId,
     units,
     quantity,
   } = props;
@@ -72,13 +72,13 @@ export function ColorMapControls(props: ColorMapControlsProps) {
   useEffect(() => {
     async function getHistogramData() {
       const response = await fetch(
-        `${SERVICE_URL}/histograms/data/${activeLayerId}`
+        `${SERVICE_URL}/histograms/data/${activeBaselayerId}`
       );
       const data: HistogramResponse = await response.json();
       setHistogramData(data);
     }
     getHistogramData();
-  }, [activeLayerId, setHistogramData]);
+  }, [activeBaselayerId, setHistogramData]);
 
   /** Determines the min, max, and step attributes for the range slider. Min and max are
         found by comparing the user-controlled (or default) 'values' to the histogram's 'edges',

--- a/src/components/ColorMapSlider.tsx
+++ b/src/components/ColorMapSlider.tsx
@@ -7,7 +7,7 @@ import './styles/color-map-controls.css';
 interface ColorMapSlideProps
   extends Omit<
     ColorMapControlsProps,
-    'activeLayerId' | 'cmap' | 'onCmapChange'
+    'activeBaselayerId' | 'cmap' | 'onCmapChange'
   > {
   /** The URL to the color map image */
   cmapImage?: string;

--- a/src/components/styles/map-baselayers.css
+++ b/src/components/styles/map-baselayers.css
@@ -1,0 +1,3 @@
+.tile-baselayer {
+  image-rendering: crisp-edges;
+}


### PR DESCRIPTION
Cherry picks non-CRS code from `crs-playground` branch relating to:
- naming improvements
- adding the CSS `image-rendering: crisp-edges;` to the tile images so they show as pixelated when zoomed beyond the tile server's tile levels
- cleans up zoom settings for the tile layer