### PR TITLE
Implement temp CRS solution

### DIFF
--- a/src/components/MapEvents.tsx
+++ b/src/components/MapEvents.tsx
@@ -6,7 +6,7 @@ import { useCallback } from 'react';
 
 type MapEventsProps = {
   /** A callback function that allows us to set state for the new baselayer */
-  onBaseLayerChange: (newLayer: L.TileLayer) => void;
+  onBaseLayerChange: (newLayer: L.TileLayer, map: L.Map) => void;
   /** The bounds of the "select area" functionality */
   selectionBounds?: L.LatLngBounds;
   /** The "highlight" boxes available in the map legend */
@@ -128,7 +128,7 @@ export function MapEvents({
 
   useMapEvents({
     baselayerchange: (e) => {
-      onBaseLayerChange(e.layer as L.TileLayer);
+      onBaseLayerChange(e.layer as L.TileLayer, map);
     },
     moveend: () => {
       if (boxes) {

--- a/src/components/layers/MapBaselayers.tsx
+++ b/src/components/layers/MapBaselayers.tsx
@@ -49,6 +49,7 @@ export function MapBaselayers({
           )}
           maxZoom={Math.max(...bands.map((b) => b.levels)) + 3}
           maxNativeZoom={band.levels - 1}
+          tileSize={band.tile_size}
         />
       </LayersControl.BaseLayer>
     );

--- a/src/configs/customCrs.ts
+++ b/src/configs/customCrs.ts
@@ -1,0 +1,22 @@
+import L from 'leaflet';
+
+/**
+ * L.CRS.EPSG4326 is an extension of L.CRS.Earth and L.CRS.Earth extends L.CRS
+ * Thus, the zoom and scale methods in EPSG4326 and Earth come from L.CRS, and
+ * L.CRS assumes a tileSize of 256 pixels. Therefore, we override those methods
+ * here with the tileSize calculated by tilemaker and provided as a property
+ * of `band`.
+ */
+export function getCustomCRS(tileSize: number) {
+  return L.Util.extend({}, L.CRS.EPSG4326, {
+    scale: function (zoom: number) {
+      // Replace 256 so that the math is based on our tile size.
+      return tileSize * Math.pow(2, zoom);
+    },
+
+    zoom: function (scale: number) {
+      // Replace 256 so that the math is based on our tile size.
+      return Math.log(scale / tileSize) / Math.LN2;
+    },
+  });
+}

--- a/src/configs/mapSettings.ts
+++ b/src/configs/mapSettings.ts
@@ -1,17 +1,12 @@
-import { CRS, MapOptions } from 'leaflet';
+import { LatLngExpression } from 'leaflet';
 
 // Uses a user-defined VITE_SERVICE_URL environment variable for development; otherwise
 // uses the window.location object's href string, minus the trailing forward slash
 export const SERVICE_URL: string =
   import.meta.env.VITE_SERVICE_URL || window.location.href.slice(0, -1);
 
-export const mapOptions: MapOptions = {
-  center: [0.0, 0.0],
-  zoom: 3,
-  crs: CRS.EPSG4326,
-};
-
-export const DEFAULT_MIN_ZOOM = 0;
+export const DEFAULT_MAP_ZOOM_LEVEL = 0;
+export const DEFAULT_MAP_CENTER: LatLngExpression = [0.0, 0.0];
 
 // related to controls
 export const NUMBER_OF_FIXED_COORDINATE_DECIMALS = 5;


### PR DESCRIPTION
This is a hack that forces the map to unmount and remount so we can use a CRS that takes into account our unorthodox tile sizes. Ideally, our tile sizes will differ by powers of 2 and Leaflet's `zoomOffset` can then handle this without forcing an unmount.