### PR TITLE
Refactor baselayer state to be in a useReducer object

### DIFF
--- a/src/components/layers/MapBaselayers.tsx
+++ b/src/components/layers/MapBaselayers.tsx
@@ -1,4 +1,4 @@
-import { Band } from '../../types/maps';
+import { Band, BaselayerState } from '../../types/maps';
 import { LayersControl, TileLayer } from 'react-leaflet';
 import { latLngBounds, latLng } from 'leaflet';
 import { makeLayerName } from '../../utils/layerUtils';
@@ -8,14 +8,8 @@ import '../styles/map-baselayers.css';
 type Props = {
   /** array of Band objects that contains a baselayer's data */
   bands: Band[];
-  /** the Band id that represents the selected baselayer; higher-up, activeBaselayer defaults to first band returned by server */
-  activeBaselayerId?: number;
-  /** the cmap used in the tile server request */
-  cmap?: string;
-  /** the vmin used in the tile server request */
-  vmin?: number;
-  /** the vmax used in the tile server request */
-  vmax?: number;
+
+  baselayerState: BaselayerState;
 };
 
 /**
@@ -23,24 +17,20 @@ type Props = {
  * @param {Props} props Refer to the props definition
  * @returns The baselayers for the Leaflet map
  */
-export function MapBaselayers({
-  bands,
-  activeBaselayerId,
-  cmap,
-  vmin,
-  vmax,
-}: Props) {
+export function MapBaselayers({ bands, baselayerState }: Props) {
+  const { activeBaselayer, cmap, cmapValues } = baselayerState;
   return bands.map((band) => {
     return (
       <LayersControl.BaseLayer
         key={`${band.map_name}-${band.id}`}
-        checked={band.id === activeBaselayerId}
+        checked={band.id === activeBaselayer!.id}
         name={makeLayerName(band)}
       >
         <TileLayer
           id={String(band.id)}
+          key={`tilelayer-${band.map_name}-${band.id}`}
           className="tile-baselayer"
-          url={`${SERVICE_URL}/maps/${band.map_id}/${band.id}/{z}/{y}/{x}/tile.png?cmap=${cmap}&vmin=${vmin}&vmax=${vmax}`}
+          url={`${SERVICE_URL}/maps/${band.map_id}/${band.id}/{z}/{y}/{x}/tile.png?cmap=${cmap}&vmin=${cmapValues!.min}&vmax=${cmapValues!.max}`}
           tms
           noWrap
           bounds={latLngBounds(

--- a/src/reducers/baselayerReducer.ts
+++ b/src/reducers/baselayerReducer.ts
@@ -1,0 +1,83 @@
+import { Band, BaselayerState } from '../types/maps';
+
+export const initialBaselayerState: BaselayerState = {
+  activeBaselayer: undefined,
+  cmap: undefined,
+  cmapValues: undefined,
+};
+
+export const CHANGE_CMAP_TYPE = 'CHANGE_CMAP';
+export const CHANGE_CMAP_VALUES = 'CHANGE_CMAP_VALUES';
+export const CHANGE_BASELAYER = 'CHANGE_BASELAYER';
+
+type ChangeCmapAction = {
+  type: typeof CHANGE_CMAP_TYPE;
+  cmap: string;
+};
+
+type ChangeCmapValuesAction = {
+  type: typeof CHANGE_CMAP_VALUES;
+  cmapValues: {
+    min: number;
+    max: number;
+  };
+};
+
+type ChangeBaselayer = {
+  type: typeof CHANGE_BASELAYER;
+  newBaselayer: Band;
+};
+
+type Action = ChangeCmapAction | ChangeCmapValuesAction | ChangeBaselayer;
+
+export function baselayerReducer(state: BaselayerState, action: Action) {
+  switch (action.type) {
+    case 'CHANGE_CMAP': {
+      return {
+        ...state,
+        cmap: action.cmap,
+      };
+    }
+    case 'CHANGE_CMAP_VALUES': {
+      return {
+        ...state,
+        cmapValues: {
+          min: action.cmapValues.min,
+          max: action.cmapValues.max,
+        },
+      };
+    }
+    case 'CHANGE_BASELAYER': {
+      const { newBaselayer } = action;
+      /**
+       * If we've yet to set an activeBaselayer or the units change between baselayers,
+       * we need to update the state of cmap properties to the band's recommended values
+       */
+      if (
+        !state.activeBaselayer ||
+        newBaselayer.units !== state.activeBaselayer.units
+      ) {
+        return {
+          cmap: newBaselayer.recommended_cmap,
+          cmapValues: {
+            min: newBaselayer.recommended_cmap_min,
+            max: newBaselayer.recommended_cmap_max,
+          },
+          activeBaselayer: newBaselayer,
+        };
+      } else {
+        /**
+         * Since units aren't changing and we have an already-defined activeBaselayer,
+         * simply set a new activeBaselayer
+         */
+        return {
+          ...state,
+          activeBaselayer: action.newBaselayer,
+        };
+      }
+    }
+    default: {
+      throw Error('Unknown action');
+    }
+  }
+}

--- a/src/types/maps.ts
+++ b/src/types/maps.ts
@@ -82,3 +82,15 @@ export type Box = {
   bottom_right_ra: number;
   bottom_right_dec: number;
 };
+
+export type BaselayerState = {
+  /** the active baselayer selected in the map's legend */
+  activeBaselayer?: Band;
+  /** the cmap matplotlib parameters used in the histogram components and tile request */
+  cmap?: string;
+  /** values for vmin and vmax matplotlib parameters used in histogram components and tile requests */
+  cmapValues?: {
+    min: number;
+    max: number;
+  };
+};


### PR DESCRIPTION
Cleans up state related to the active `baselayer` by consolidating and/or removing state. Previously, different actions entailed a number of `setState` updates and some state, like `tileSize`, was redundant since it's included in the `Band` objects used for the baselayers.