### PR TITLE
Keyboard support to cmap

### DIFF
--- a/src/components/ColorMapSlider.tsx
+++ b/src/components/ColorMapSlider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Range as RangeSlider, getTrackBackground } from 'react-range';
 import { formatNumberForDisplay } from '../utils/numberUtils';
 import { ColorMapControlsProps } from './ColorMapControls';
@@ -32,41 +32,48 @@ export function ColorMapSlider(props: ColorMapSlideProps) {
    * the RangeSlider has an onFinalChange handler that will set the global state once a user releases the slider handle
    */
   const [tempValues, setTempValues] = useState([values[0], values[1]]);
+  const prevKeyUpHandler = useRef<(e: KeyboardEvent) => void>(null);
+  const prevKeyDownHandler = useRef<(e: KeyboardEvent) => void>(null);
 
   useEffect(() => {
-    // const heldKeyRef = { current: null as string | null };
-
+    if (prevKeyUpHandler.current) {
+      document.removeEventListener('keyup', prevKeyUpHandler.current);
+    }
+    if (prevKeyDownHandler.current) {
+      document.removeEventListener('keydown', prevKeyDownHandler.current);
+    }
     const handleKeyUp = (e: KeyboardEvent) => {
       if ((e.target as HTMLElement)?.closest('input')) return;
 
-      // Avoid repeated firing if key is held down
+      // Only set and fetch cmap settings when keyup is fired
+      // so we're not fetching while keydown is firing
       onCmapValuesChange(tempValues);
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.target as HTMLElement)?.closest('input')) return;
 
-      // if (e.key !== heldKeyRef.current) return; // Ignore if different key
-      // heldKeyRef.current = null;
-
       switch (e.key) {
         case 'a':
           setTempValues((prev) => [prev[0] - 1, prev[1] - 1]);
           break;
-        case 'f':
+        case 'd':
           setTempValues((prev) => [prev[0] + 1, prev[1] + 1]);
           break;
-        case 's':
+        case 'w':
           setTempValues((prev) => [prev[0] - 1, prev[1] + 1]);
           break;
-        case 'd':
+        case 's':
           setTempValues((prev) => [prev[0] + 1, prev[1] - 1]);
           break;
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
+    prevKeyDownHandler.current = handleKeyDown;
+
     document.addEventListener('keyup', handleKeyUp);
+    prevKeyUpHandler.current = handleKeyUp;
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
Closes https://github.com/simonsobs/tileviewer/issues/34

Uses `a`/`d` and `w`/`s` as described in the issue.