### PR TITLE
Quick fixes post DM call

### DIFF
--- a/src/components/BaselayerHistoryNavigation.tsx
+++ b/src/components/BaselayerHistoryNavigation.tsx
@@ -20,7 +20,7 @@ export function BaselayerHistoryNavigation({
         <button
           type="button"
           className="map-btn"
-          title="Type 'h' or click to go back one baselayer"
+          title="Type 'H' or click to go back one baselayer"
           disabled={disableGoBack}
           onClick={goBack}
         >
@@ -31,7 +31,7 @@ export function BaselayerHistoryNavigation({
         <button
           type="button"
           className="map-btn"
-          title="Type 'l' or click to go forward one baselayer"
+          title="Type 'L' or click to go forward one baselayer"
           disabled={disableGoForward}
           onClick={goForward}
         >

--- a/src/components/OpenLayersMap.tsx
+++ b/src/components/OpenLayersMap.tsx
@@ -85,7 +85,7 @@ export function OpenLayersMap({
   );
   const [isDrawing, setIsDrawing] = useState(false);
   const [isNewBoxDrawn, setIsNewBoxDrawn] = useState(false);
-  const [flipTiles, setFlipTiles] = useState(false);
+  const [flipTiles, setFlipTiles] = useState(true);
 
   const [backHistoryStack, setBackHistoryStack] = useState<
     { id: string; flipped: boolean }[]
@@ -309,7 +309,7 @@ export function OpenLayersMap({
 
   const handleSearchOverlay = useCallback(
     (e: MapBrowserEvent) => {
-      if (e.originalEvent.metaKey) {
+      if (e.originalEvent.shiftKey) {
         const simbadOverlay = e.map.getOverlayById('simbad-search-overlay');
         if (simbadOverlay) {
           if (externalSearchRef.current) {


### PR DESCRIPTION
1. Replace 'l' and 'k' with 'L' and 'K' in baselayer history button tooltips so there's no ambiguity what 'l' is.
2. Replace meta + click with shift + click to enable the external search
3. Default flipped tile state to be true (resulting in 360>ra>0 as default)